### PR TITLE
Fix in R Package Installation

### DIFF
--- a/docs/get_started/build.md
+++ b/docs/get_started/build.md
@@ -218,6 +218,8 @@ To install the R package. First finish the [Build MXNet Library](#build-mxnet-li
 Then use the following command to install dependencies and build the package at root folder
 
 ```bash
+sudo apt-get -y build-dep libcurl4-gnutls-dev
+sudo apt-get -y install libcurl4-gnutls-dev
 Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
 cd R-package
 Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"


### PR DESCRIPTION
Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')" failed due to missing developer version of the curl lib.

Found solution here

http://stackoverflow.com/questions/31114991/installation-of-package-devtools-had-non-zero-exit-status-in-a-powerpc